### PR TITLE
Update download.js

### DIFF
--- a/download.js
+++ b/download.js
@@ -47,8 +47,8 @@ var processCourseInfo = function(body)
 		videos = body.lessonData.map(function(obj, index){
 			var seq 		= index + 1,
 				url 		= API_BASE + '/video/' + obj.statsId + '?r=720&f=webm',
-				destination = directory + '/' + seq + ' - ' + obj.title + '.webm',
-				title 		= obj.title;
+				destination = directory + '/' + seq + ' - ' + obj.slug + '.webm',
+				title 		= obj.slug;
 
 			return {
 				url 		: url,


### PR DESCRIPTION
Some time video stops to download. due to file creation issue. because some special character is not allowed in a file name.